### PR TITLE
Use cached length for Polyline hermite interpolation.

### DIFF
--- a/TruckLib/HermiteSpline.cs
+++ b/TruckLib/HermiteSpline.cs
@@ -14,9 +14,9 @@ namespace TruckLib
     /// </summary>
     public static class HermiteSpline
     {
-        public static Vector3 InterpolatePolyline(INode start, INode end, float t)
+        public static Vector3 InterpolatePolyline(INode start, INode end, float t, float? cachedLength = null)
         {
-            var (tanStart, tanEnd) = CalculateTangents(start, end);
+            var (tanStart, tanEnd) = CalculateTangents(start, end, cachedLength);
             return Interpolate(start.Position, end.Position, tanStart, tanEnd, t);
         }
 
@@ -30,9 +30,9 @@ namespace TruckLib
                 (t3 - t2) * m1;
         }
 
-        public static Vector3 DerivativePolyline(INode start, INode end, float t)
+        public static Vector3 DerivativePolyline(INode start, INode end, float t, float? cachedLength = null)
         {
-            var (tanStart, tanEnd) = CalculateTangents(start, end);
+            var (tanStart, tanEnd) = CalculateTangents(start, end, cachedLength);
             return Derivative(start.Position, end.Position, tanStart, tanEnd, t);
         }
 
@@ -45,9 +45,9 @@ namespace TruckLib
                 (3 * t2 - 2 * t) * m1;
         }
 
-        internal static (Vector3 tanStart, Vector3 tanEnd) CalculateTangents(INode start, INode end)
+        internal static (Vector3 tanStart, Vector3 tanEnd) CalculateTangents(INode start, INode end, float? cachedLength = null)
         {
-            var length = (end.Position - start.Position).Length();
+            var length = cachedLength ?? (end.Position - start.Position).Length();
             var initialVector = new Vector3(0, 0, -length);
             var tanStart = Vector3.Transform(initialVector, start.Rotation);
             var tanEnd = Vector3.Transform(initialVector, end.Rotation);

--- a/TruckLib/ScsMap/PolylineItem.cs
+++ b/TruckLib/ScsMap/PolylineItem.cs
@@ -399,8 +399,8 @@ namespace TruckLib.ScsMap
         /// <returns>The position and rotation of the point at <em>t</em>.</returns>
         public OrientedPoint InterpolateCurve(float t)
         {
-            var position = HermiteSpline.InterpolatePolyline(Node, ForwardNode, t);
-            var rotation = MathEx.GetNodeRotation(HermiteSpline.DerivativePolyline(Node, ForwardNode, t));
+            var position = HermiteSpline.InterpolatePolyline(Node, ForwardNode, t, cachedLength: Length);
+            var rotation = MathEx.GetNodeRotation(HermiteSpline.DerivativePolyline(Node, ForwardNode, t, cachedLength: Length));
             return new OrientedPoint(position, rotation);
         }
 


### PR DESCRIPTION
**Before**
<img width="600" alt="Screenshot_20260628_122347" src="https://github.com/user-attachments/assets/36151adb-70f8-4813-a7e9-b6bafd7e33e0" />
**After**
<img width="600" alt="Screenshot_20260628_122544" src="https://github.com/user-attachments/assets/0e4635d7-67f2-4fc7-8ee0-68f6d94e5b7b" />


I noticed that in ETS2LA we were having issues with cutting corners. Initially I thought this must've been a fault of the hermite algorithm itself, but after checking the code it seems like the repository was using euclidian distance for determining the length of the spline.

The more pronounced the curve is, the more this will show up in the output. Luckily since `PolylineItem`s already have a cached length we can pass that in directly to the tangent calculation to resolve the issue. 